### PR TITLE
Misc cleanup

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -12,6 +12,7 @@
         "@typescript-eslint/no-non-null-assertion": "off",
         "@typescript-eslint/camelcase": "off",
         "@typescript-eslint/member-naming": "off",
+        "@typescript-eslint/no-unused-vars": ["error", { "argsIgnorePattern": "^_" }],
         "@typescript-eslint/member-ordering": [
             "error",
             {

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ try {
     // Set a JS function to be a global lua function
     lua.global.set('sum', (x, y) => x + y)
     // Run a lua string
-    lua.doString(`
+    await lua.doString(`
     print(sum(10, 10))
     function multiply(x, y)
         return x * y

--- a/bin/wasmoon
+++ b/bin/wasmoon
@@ -11,12 +11,16 @@ if (snippets.length === 2 && snippets[0] === '-f') {
     code = fs.readFileSync(0, 'utf-8');
 }
 
-(async () => {
+async function main() {
     const lua = await new LuaFactory().createEngine();
-
     try {
-        lua.doString(code);
+        console.log(await lua.doString(code));
     } finally {
         lua.global.close();
     }
-})();
+}
+
+main().catch(err => {
+    console.error(err);
+    process.exit(1);
+});

--- a/src/decoration.ts
+++ b/src/decoration.ts
@@ -1,24 +1,11 @@
-export class Decoration {
-    constructor(public target: any, public options: any) {}
+export interface BaseDecorationOptions {
+    metatable?: Record<any, any>
 }
 
-export const decorateFunction = (
-    target: Function,
-    options: Partial<{
-        rawArguments: number[]
-        receiveThread: boolean
-        rawResult: boolean
-    }>,
-): Decoration => {
-    return new Decoration(target, options)
+export class Decoration<T = any, K extends BaseDecorationOptions = BaseDecorationOptions> {
+    public constructor(public target: T, public options: K) {}
 }
 
-export const decorate = (
-    target: object,
-    options: Partial<{
-        reference: boolean
-        metatable: object
-    }>,
-): Decoration => {
-    return new Decoration(target, options)
+export function decorate(target: any, options: BaseDecorationOptions): Decoration<any, BaseDecorationOptions> {
+    return new Decoration<any, BaseDecorationOptions>(target, options)
 }

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -2,7 +2,9 @@ import { LuaEngineOptions } from './types'
 import Global from './global'
 import Thread from './thread'
 import createErrorType from './type-extensions/error'
+import createFunctionType from './type-extensions/function'
 import createPromiseType from './type-extensions/promise'
+import createTableType from './type-extensions/table'
 import createUserdataType from './type-extensions/userdata'
 import type LuaWasm from './luawasm'
 
@@ -22,9 +24,13 @@ export default class Lua {
             ...(userOptions || {}),
         }
 
-        this.global.registerTypeExtension(createErrorType(this.global, options.injectObjects))
-        this.global.registerTypeExtension(createPromiseType(this.global, options.injectObjects))
-        this.global.registerTypeExtension(createUserdataType(this.global))
+        // Generic handlers - These may be required to be registered for additional types.
+        this.global.registerTypeExtension(0, createTableType(this.global))
+        this.global.registerTypeExtension(0, createFunctionType(this.global))
+        // Specific type handlers. These depend on the above but should be evaluated first.
+        this.global.registerTypeExtension(1, createErrorType(this.global, options.injectObjects))
+        this.global.registerTypeExtension(1, createPromiseType(this.global, options.injectObjects))
+        this.global.registerTypeExtension(2, createUserdataType(this.global))
 
         if (this.global.isClosed()) {
             throw new Error('Lua state could not be created (probably due to lack of memory)')

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,8 @@ export { default as MultiReturn } from './multireturn'
 // Export the underlying bindings to allow users to just
 // use the bindings rather than the wrappers.
 export { default as LuaWasm } from './luawasm'
-export { decorateFunction, decorate } from './decoration'
+export { decorateFunction } from './type-extensions/function'
+export { decorateUserData } from './type-extensions/userdata'
+export { decorate } from './decoration'
 export { default as LuaTypeExtension } from './type-extension'
 export * from './types'

--- a/src/type-extensions/error.ts
+++ b/src/type-extensions/error.ts
@@ -1,3 +1,4 @@
+import { Decoration } from '../decoration'
 import { LuaReturn, LuaState } from '../types'
 import Thread from '../thread'
 import TypeExtension from '../type-extension'
@@ -60,11 +61,11 @@ class ErrorTypeExtension extends TypeExtension<Error> {
         }
     }
 
-    public pushValue(thread: Thread, value: unknown, decorations: Record<string, any>): boolean {
-        if (!(value instanceof Error)) {
+    public pushValue(thread: Thread, decoration: Decoration<Error>): boolean {
+        if (!(decoration.target instanceof Error)) {
             return false
         }
-        return super.pushValue(thread, value, decorations)
+        return super.pushValue(thread, decoration)
     }
 
     public close(): void {

--- a/src/type-extensions/function.ts
+++ b/src/type-extensions/function.ts
@@ -1,0 +1,185 @@
+import { BaseDecorationOptions, Decoration } from '../decoration'
+import { LUA_REGISTRYINDEX, LuaReturn, LuaState, LuaType, PointerSize } from '../types'
+import MultiReturn from '../multireturn'
+import Thread from '../thread'
+import TypeExtension from '../type-extension'
+
+export interface FunctionDecoration extends BaseDecorationOptions {
+    rawArguments?: number[]
+    receiveThread?: boolean
+    rawResult?: boolean
+}
+
+export type FunctionType = (...args: any[]) => Promise<any> | any
+
+export function decorateFunction(target: FunctionType, options: FunctionDecoration): Decoration<FunctionType, FunctionDecoration> {
+    return new Decoration<FunctionType, FunctionDecoration>(target, options)
+}
+
+declare global {
+    const FinalizationRegistry: any
+}
+
+class FunctionTypeExtension extends TypeExtension<FunctionType, FunctionDecoration> {
+    private readonly functionRegistry =
+        typeof FinalizationRegistry !== 'undefined'
+            ? new FinalizationRegistry((func: number) => {
+                  if (!this.thread.isClosed()) {
+                      this.thread.cmodule.luaL_unref(this.thread.address, LUA_REGISTRYINDEX, func)
+                  }
+              })
+            : undefined
+
+    private gcPointer: number
+
+    public constructor(thread: Thread) {
+        super(thread, 'js_function')
+
+        this.gcPointer = thread.cmodule.module.addFunction((calledL: LuaState) => {
+            // Throws a lua error which does a jump if it does not match.
+            const userDataPointer = thread.cmodule.luaL_checkudata(calledL, 1, this.name)
+            const functionPointer = thread.cmodule.module.getValue(userDataPointer, '*')
+            // Safe to do without a reference count because each time a function is pushed it creates a new and unique
+            // anonymous function.
+            thread.cmodule.module.removeFunction(functionPointer)
+
+            return LuaReturn.Ok
+        }, 'ii')
+
+        // Creates metatable if it doesn't exist, always pushes it onto the stack.
+        if (thread.cmodule.luaL_newmetatable(thread.address, this.name)) {
+            thread.cmodule.lua_pushstring(thread.address, '__gc')
+            thread.cmodule.lua_pushcclosure(thread.address, this.gcPointer, 0)
+            thread.cmodule.lua_settable(thread.address, -3)
+
+            thread.cmodule.lua_pushstring(thread.address, '__metatable')
+            thread.cmodule.lua_pushstring(thread.address, 'protected metatable')
+            thread.cmodule.lua_settable(thread.address, -3)
+        }
+        // Pop the metatable from the stack.
+        thread.cmodule.lua_pop(thread.address, 1)
+    }
+
+    public close(): void {
+        this.thread.cmodule.module.removeFunction(this.gcPointer)
+    }
+
+    public isType(_thread: Thread, _index: number, type: LuaType): boolean {
+        return type === LuaType.Function
+    }
+
+    public pushValue(thread: Thread, decoratedValue: Decoration<FunctionType, FunctionDecoration>): boolean {
+        const { target, options } = decoratedValue
+        if (typeof target !== 'function') {
+            return false
+        }
+
+        const pointer = thread.cmodule.module.addFunction((calledL: LuaState) => {
+            const argsQuantity = thread.cmodule.lua_gettop(calledL)
+            const args = []
+
+            const calledThread = thread.stateToThread(calledL)
+
+            if (options.receiveThread) {
+                args.push(calledThread)
+            }
+
+            for (let i = 1; i <= argsQuantity; i++) {
+                if (options?.rawArguments?.includes(i - 1)) {
+                    args.push(calledThread.getPointer(i))
+                } else {
+                    args.push(calledThread.getValue(i))
+                }
+            }
+
+            if (options?.rawResult) {
+                // Interestingly yieldk does a longjmp and that's handled
+                // by throwing an error. So for anything that yields it needs
+                // to not be in the try/catch.
+                const result = target(...args)
+                if (typeof result !== 'number') {
+                    throw new Error('result must be a number')
+                }
+                return result
+            }
+
+            try {
+                const result = target(...args)
+
+                if (result === undefined) {
+                    return 0
+                }
+                if (result instanceof MultiReturn) {
+                    for (const item of result) {
+                        calledThread.pushValue(item)
+                    }
+                    return result.length
+                } else {
+                    calledThread.pushValue(result)
+                    return 1
+                }
+            } catch (err) {
+                calledThread.pushValue(err)
+                return thread.cmodule.lua_error(calledThread.address)
+            }
+        }, 'ii')
+        // Creates a new userdata with metatable pointing to the function pointer.
+        // Pushes the new userdata onto the stack.
+        this.createAndPushFunctionReference(thread, pointer)
+        // Pass 1 to associate the closure with the userdata.
+        thread.cmodule.lua_pushcclosure(thread.address, pointer, 1)
+
+        return true
+    }
+
+    public getValue(thread: Thread, index: number): FunctionType {
+        thread.cmodule.lua_pushvalue(thread.address, index)
+        const func = thread.cmodule.luaL_ref(thread.address, LUA_REGISTRYINDEX)
+
+        const jsFunc = (...args: any[]): any => {
+            if (thread.isClosed()) {
+                console.warn('Tried to call a function after closing lua state')
+                return
+            }
+
+            const internalType = thread.cmodule.lua_rawgeti(thread.address, LUA_REGISTRYINDEX, func)
+            if (internalType !== LuaType.Function) {
+                throw new Error(`A function of type '${internalType}' was pushed, expected is ${LuaType.Function}`)
+            }
+
+            for (const arg of args) {
+                thread.pushValue(arg)
+            }
+
+            const startTop = thread.getTop()
+            thread.cmodule.lua_callk(thread.address, args.length, 1, 0, null)
+            const res = thread.getValue(-1)
+            thread.setTop(startTop)
+            return res
+        }
+
+        this.functionRegistry?.register(jsFunc, func)
+
+        return jsFunc
+    }
+
+    private createAndPushFunctionReference(thread: Thread, pointer: number): void {
+        // 4 = size of pointer in wasm.
+        const userDataPointer = thread.cmodule.lua_newuserdatauv(thread.address, PointerSize, 0)
+        thread.cmodule.module.setValue(userDataPointer, pointer, '*')
+
+        if (LuaType.Nil === thread.cmodule.luaL_getmetatable(thread.address, this.name)) {
+            // Pop the pushed nil value and user data
+            thread.pop(2)
+            throw new Error(`metatable not found: ${this.name}`)
+        }
+
+        // Set as the metatable for the userdata.
+        // -1 is the metatable, -2 is the user data.
+        thread.cmodule.lua_setmetatable(thread.address, -2)
+    }
+}
+
+export default function createTypeExtension(thread: Thread): TypeExtension<FunctionType, FunctionDecoration> {
+    return new FunctionTypeExtension(thread)
+}

--- a/src/type-extensions/promise.ts
+++ b/src/type-extensions/promise.ts
@@ -1,5 +1,6 @@
+import { Decoration } from '../decoration'
 import { LuaReturn, LuaState } from '../types'
-import { decorateFunction } from '../decoration'
+import { decorateFunction } from './function'
 import Thread from '../thread'
 import TypeExtension from '../type-extension'
 
@@ -126,11 +127,11 @@ class PromiseTypeExtension<T = unknown> extends TypeExtension<Promise<T>> {
         this.thread.cmodule.module.removeFunction(this.gcPointer)
     }
 
-    public pushValue(thread: Thread, value: unknown, decorations: Record<string, any>): boolean {
-        if (Promise.resolve(value) !== value) {
+    public pushValue(thread: Thread, decoration: Decoration<Promise<T>>): boolean {
+        if (Promise.resolve(decoration.target) !== decoration.target) {
             return false
         }
-        return super.pushValue(thread, value, decorations)
+        return super.pushValue(thread, decoration)
     }
 }
 

--- a/src/type-extensions/table.ts
+++ b/src/type-extensions/table.ts
@@ -1,0 +1,130 @@
+import { Decoration } from '../decoration'
+import { LUA_REGISTRYINDEX, LuaType } from '../types'
+import Thread from '../thread'
+import TypeExtension from '../type-extension'
+
+export type TableType = Record<any, any> | any[]
+
+class TableTypeExtension extends TypeExtension<TableType> {
+    public constructor(thread: Thread) {
+        super(thread, 'js_table')
+    }
+
+    public close(): void {
+        // Nothing to do
+    }
+
+    public isType(_thread: Thread, _index: number, type: LuaType): boolean {
+        return type === LuaType.Table
+    }
+
+    public getValue(thread: Thread, index: number, userdata?: any): TableType {
+        // This is a map of Lua pointers to JS objects.
+        const seenMap = userdata || new Map<number, Record<any, any>>()
+        const pointer = thread.cmodule.lua_topointer(thread.address, index)
+
+        const table = seenMap.get(pointer) || {}
+        if (!seenMap.has(pointer)) {
+            seenMap.set(pointer, table)
+            this.getTable(thread, index, seenMap, table)
+        }
+
+        const tableLength = Object.keys(table).length
+        // Specifically return an object if there's no way of telling whether
+        // it's an array or object.
+        if (tableLength === 0) {
+            return table
+        }
+
+        let isArray = true
+        const array: any[] = []
+        for (let i = 1; i <= tableLength; i++) {
+            const value = table[String(i)]
+            if (value === undefined) {
+                isArray = false
+                break
+            }
+            array.push(value)
+        }
+
+        return isArray ? array : table
+    }
+
+    public pushValue(thread: Thread, decoratedValue: Decoration<TableType>, userdata?: any): boolean {
+        const { target, options } = decoratedValue
+        if (typeof target !== 'object' || target === null) {
+            return false
+        }
+
+        // This is a map of JS objects to luaL references.
+        const seenMap = userdata || new Map<any, number>()
+        const existingReference = seenMap.get(target)
+        if (existingReference !== undefined) {
+            thread.cmodule.lua_rawgeti(thread.address, LUA_REGISTRYINDEX, existingReference)
+            return true
+        }
+
+        try {
+            const tableIndex = thread.getTop() + 1
+
+            const createTable = (arrayCount: number, keyCount: number): void => {
+                thread.cmodule.lua_createtable(thread.address, arrayCount, keyCount)
+                const ref = thread.cmodule.luaL_ref(thread.address, LUA_REGISTRYINDEX)
+                seenMap.set(target, ref)
+                thread.cmodule.lua_rawgeti(thread.address, LUA_REGISTRYINDEX, ref)
+            }
+
+            if (Array.isArray(target)) {
+                createTable(target.length, 0)
+
+                for (let i = 0; i < target.length; i++) {
+                    thread.pushValue(i + 1, seenMap)
+                    thread.pushValue(target[i], seenMap)
+
+                    thread.cmodule.lua_settable(thread.address, tableIndex)
+                }
+            } else {
+                createTable(0, Object.getOwnPropertyNames(target).length)
+
+                for (const key in target) {
+                    thread.pushValue(key, seenMap)
+                    thread.pushValue((target as Record<string, any>)[key], seenMap)
+
+                    thread.cmodule.lua_settable(thread.address, tableIndex)
+                }
+            }
+
+            if (typeof options.metatable === 'object') {
+                thread.pushValue(options.metatable)
+                thread.cmodule.lua_setmetatable(thread.address, tableIndex)
+            }
+        } finally {
+            if (userdata === undefined) {
+                for (const reference of seenMap.values()) {
+                    thread.cmodule.luaL_unref(thread.address, LUA_REGISTRYINDEX, reference)
+                }
+            }
+        }
+
+        return true
+    }
+
+    private getTable(thread: Thread, index: number, seenMap: Map<number, Record<any, any>>, table: Record<any, any>): void {
+        thread.cmodule.lua_pushnil(thread.address)
+
+        while (thread.cmodule.lua_next(thread.address, index)) {
+            // JS only supports string keys in objects.
+            const key = thread.cmodule.luaL_tolstring(thread.address, -2, null)
+            thread.pop()
+            const value = thread.getValue(-1, undefined, seenMap)
+
+            table[key] = value
+
+            thread.pop()
+        }
+    }
+}
+
+export default function createTypeExtension(thread: Thread): TypeExtension<any> {
+    return new TableTypeExtension(thread)
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -38,12 +38,3 @@ export enum LuaType {
     UserData = 7,
     Thread = 8,
 }
-
-export enum LuaMetatables {
-    FunctionReference = 'function_reference',
-    JsReference = 'js_reference',
-}
-
-declare global {
-    const FinalizationRegistry: any
-}

--- a/test/engine.test.js
+++ b/test/engine.test.js
@@ -291,3 +291,18 @@ test('limit memory use causes program runtime failure succeeds', async () => {
 
     await expect(engine.global.run()).rejects.toThrow('Lua Error(ErrorMem/4): not enough memory')
 })
+
+test('table supported circular dependencies', async () => {
+    const engine = await getEngine()
+
+    const a = { name: 'a' }
+    const b = { name: 'b' }
+    b.a = a
+    a.b = b
+
+    engine.global.pushValue(a)
+    const res = engine.global.getValue(-1)
+
+    // Jest does not cope well with comparing these
+    expect(res.b.a === res).toEqual(true)
+})


### PR DESCRIPTION
* Convert function and table to type extensions
* Add type extension priorities to allow more vague converters
  like table to be loaded first but matched after more specific
  objects types such as promise.
* Fixed README and bin/wasmoon