### PR TITLE
Fixed tables getting metatables twice

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -46,6 +46,7 @@
             "rules": {
                 "@typescript-eslint/no-var-requires": "off",
                 "@typescript-eslint/no-require-imports": "off",
+                "@typescript-eslint/explicit-function-return-type": "off",
                 "no-undef": "off"
             }
         }

--- a/src/type-extensions/table.ts
+++ b/src/type-extensions/table.ts
@@ -51,7 +51,7 @@ class TableTypeExtension extends TypeExtension<TableType> {
     }
 
     public pushValue(thread: Thread, decoratedValue: Decoration<TableType>, userdata?: any): boolean {
-        const { target, options } = decoratedValue
+        const { target } = decoratedValue
         if (typeof target !== 'object' || target === null) {
             return false
         }
@@ -92,11 +92,6 @@ class TableTypeExtension extends TypeExtension<TableType> {
 
                     thread.cmodule.lua_settable(thread.address, tableIndex)
                 }
-            }
-
-            if (typeof options.metatable === 'object') {
-                thread.pushValue(options.metatable)
-                thread.cmodule.lua_setmetatable(thread.address, tableIndex)
             }
         } finally {
             if (userdata === undefined) {


### PR DESCRIPTION
Also added a demo of wrapping native JS classes

@ceifa Sorry for the bug, though hopefully this now resolves the original that had a memory leak and my one :)