### PR TITLE
Allow returning a raw result from a promise

### DIFF
--- a/src/global.ts
+++ b/src/global.ts
@@ -103,6 +103,7 @@ export default class Global extends Thread {
                 this.lua.luaopen_package(this.address)
                 break
         }
+        this.lua.lua_setglobal(this.address, library)
     }
 
     public get(name: string): any {

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ export { default as LuaEngine } from './engine'
 export { default as LuaThread } from './thread'
 export { default as LuaGlobal } from './global'
 export { default as LuaMultiReturn } from './multireturn'
+export { default as LuaRawResult } from './raw-result'
 // Export the underlying bindings to allow users to just
 // use the bindings rather than the wrappers.
 export { default as LuaWasm } from './luawasm'

--- a/src/raw-result.ts
+++ b/src/raw-result.ts
@@ -1,0 +1,7 @@
+export default class RawResult {
+    public readonly count: number
+
+    public constructor(count: number) {
+        this.count = count
+    }
+}


### PR DESCRIPTION
* Allow returning a raw result count and multireturn from promise:await()
* Return a RawResult class rather than using a decorator
* All all functions to throw a longjmp
* Fixed library loading not setting globals