### PR TITLE
JS callack error checking

### DIFF
--- a/src/global.ts
+++ b/src/global.ts
@@ -38,6 +38,9 @@ export default class Global extends Thread {
         }, 'iiiii')
 
         const address = cmodule.lua_newstate(allocatorFunctionPointer, null)
+        if (!address) {
+            throw new Error('lua_newstate returned a null pointer')
+        }
         super(cmodule, [], address)
 
         this.memoryStats = memoryStats

--- a/src/thread.ts
+++ b/src/thread.ts
@@ -38,7 +38,11 @@ export default class Thread {
     }
 
     public newThread(): Thread {
-        return new Thread(this.lua, this.typeExtensions, this.lua.lua_newthread(this.address))
+        const address = this.lua.lua_newthread(this.address)
+        if (!address) {
+            throw new Error('lua_newthread returned a null pointer')
+        }
+        return new Thread(this.lua, this.typeExtensions, address)
     }
 
     public resetThread(): void {

--- a/src/thread.ts
+++ b/src/thread.ts
@@ -352,19 +352,20 @@ export default class Thread {
         }
     }
 
-    private assertOk(result: LuaReturn): void {
+    public assertOk(result: LuaReturn): void {
         if (result !== LuaReturn.Ok && result !== LuaReturn.Yield) {
             const resultString = LuaReturn[result]
+            // This is the default message if there's nothing on the stack.
             let message = `Lua Error(${resultString}/${result})`
             if (this.getTop() > 0) {
                 if (result === LuaReturn.ErrorMem) {
                     // If there's no memory just do a normal to string.
                     const error = this.lua.lua_tolstring(this.address, -1, null)
-                    message += `: ${error}`
+                    message = error
                 } else {
                     // Calls __tostring if it exists and pushes onto the stack.
                     const error = this.indexToString(-1)
-                    message += `: ${error}`
+                    message = error
                 }
             }
             throw new Error(message)

--- a/src/type-extensions/error.ts
+++ b/src/type-extensions/error.ts
@@ -41,7 +41,9 @@ class ErrorTypeExtension extends TypeExtension<Error> {
 
             // Add a tostring method that returns the message.
             thread.pushValue((jsRefError: Error) => {
-                return jsRefError.toString()
+                // The message rather than toString to avoid the Error: prefix being
+                // added. This fits better with Lua errors.
+                return jsRefError.message
             })
             thread.lua.lua_setfield(thread.address, metatableIndex, '__tostring')
         }

--- a/src/type-extensions/function.ts
+++ b/src/type-extensions/function.ts
@@ -145,7 +145,12 @@ class FunctionTypeExtension extends TypeExtension<FunctionType, FunctionDecorati
                 thread.pushValue(arg)
             }
 
-            thread.lua.lua_callk(thread.address, args.length, 1, 0, null)
+            const status = thread.lua.lua_pcallk(thread.address, args.length, 1, 0, 0, null)
+            if (status === LuaReturn.Yield) {
+                throw new Error('cannot yield in callbacks from javascript')
+            }
+            thread.assertOk(status)
+
             const result = thread.getValue(-1)
 
             thread.pop()

--- a/test/engine.test.js
+++ b/test/engine.test.js
@@ -278,7 +278,7 @@ test('limit memory use causes program loading failure succeeds', async () => {
             local b = 20
             return a + b
         `)
-    }).toThrow('Lua Error(ErrorMem/4): not enough memory')
+    }).toThrow('not enough memory')
 
     // Remove the limit and retry
     engine.global.setMemoryMax(undefined)
@@ -299,7 +299,7 @@ test('limit memory use causes program runtime failure succeeds', async () => {
     `)
     engine.global.setMemoryMax(engine.global.getMemoryUsed())
 
-    await expect(engine.global.run()).rejects.toThrow('Lua Error(ErrorMem/4): not enough memory')
+    await expect(engine.global.run()).rejects.toThrow('not enough memory')
 })
 
 test('table supported circular dependencies', async () => {

--- a/test/promises.test.js
+++ b/test/promises.test.js
@@ -283,3 +283,21 @@ test('resolve multiple promises with promise.all', async () => {
 
     expect(res).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9, 10])
 })
+
+test('error in promise next catchable', async () => {
+    const engine = await getEngine()
+    engine.global.set('sleep', (input) => new Promise((resolve) => setTimeout(resolve, input)))
+    const resPromise = engine
+        .doString(
+            `
+        return sleep(1):next(function ()
+            error("sleep done")
+        end):await()
+    `,
+        )
+        .catch((err) => {
+            expect(err.message).toContain('[string "..."]:3: sleep done')
+        })
+    jest.advanceTimersByTime(50)
+    await resPromise
+})


### PR DESCRIPTION
* Checked for out-of-memory error when creating a new state.
* Stopped errors getting recursively prefixed with "LuaError (?): LuaError (?)....."
* When calling a Lua callback from JS the result value is now checked and thrown as JS error. Also explicitly throw an error if yielding in a JS callback.