### PR TITLE
Fixed unncessary yields for timeouts

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -29,7 +29,6 @@ export interface LuaEngineOptions {
 
 export interface LuaThreadRunOptions {
     timeout?: number
-    forcedYieldCount?: number
 }
 
 export const PointerSize = 4

--- a/test/engine.test.js
+++ b/test/engine.test.js
@@ -408,7 +408,7 @@ test('timeout blocking lua program', async () => {
         while true do i = i + 1 end
     `)
 
-    await expect(thread.run(0, { timeout: 5, forcedYieldCount: 1000 })).rejects.toThrow('run exceeded timeout of 5ms')
+    await expect(thread.run(0, { timeout: 5 })).rejects.toThrow('thread timeout exceeded')
 })
 
 test('overwrite lib function', async () => {


### PR DESCRIPTION
This resolves #34 by only yielding in the timeout hook when a timeout has occurred instead of every X instructions. This fixes yielding in JS callbacks causing an inconsistent state.