### PR TITLE
Fixed timeout could only be set the first time

### DIFF
--- a/src/thread.ts
+++ b/src/thread.ts
@@ -312,10 +312,9 @@ export default class Thread {
                         this.lua.lua_error(this.address)
                     }
                 }, 'vii')
-
-                this.lua.lua_sethook(this.address, this.hookFunctionPointer, LuaEventMasks.Count, INSTRUCTION_HOOK_COUNT)
             }
 
+            this.lua.lua_sethook(this.address, this.hookFunctionPointer, LuaEventMasks.Count, INSTRUCTION_HOOK_COUNT)
             this.timeout = timeout
         } else {
             this.timeout = undefined


### PR DESCRIPTION
If disabled then it would the hook would be set to null in C but then on the next call the hook would not be fully re-enabled because it already existed.

Introduced in #36 but I only noticed after it'd been merged :)