### PR TITLE
Fix awaiting Promises when using with Angular

### DIFF
--- a/src/type-extensions/promise.ts
+++ b/src/type-extensions/promise.ts
@@ -34,7 +34,7 @@ class PromiseTypeExtension<T = unknown> extends TypeExtension<Promise<T>> {
             thread.lua.lua_setfield(thread.address, metatableIndex, '__gc')
 
             const checkSelf = (self: Promise<any>): true => {
-                if (Promise.resolve(self) !== self) {
+                if (Promise.resolve(self) !== self && typeof self.then !== 'function') {
                     throw new Error('promise method called without self instance')
                 }
                 return true
@@ -131,7 +131,7 @@ class PromiseTypeExtension<T = unknown> extends TypeExtension<Promise<T>> {
     }
 
     public pushValue(thread: Thread, decoration: Decoration<Promise<T>>): boolean {
-        if (Promise.resolve(decoration.target) !== decoration.target) {
+        if (Promise.resolve(decoration.target) !== decoration.target && typeof decoration.target.then !== 'function') {
             return false
         }
         return super.pushValue(thread, decoration)

--- a/src/type-extensions/proxy.ts
+++ b/src/type-extensions/proxy.ts
@@ -150,7 +150,7 @@ class ProxyTypeExtension extends TypeExtension<any, ProxyDecorationOptions> {
                 }
             }
 
-            if (Promise.resolve(target) === target) {
+            if (Promise.resolve(target) === target || typeof target.then === 'function') {
                 return false
             }
         } else if (options.proxy === false) {


### PR DESCRIPTION
The existing checks for determining if the object is actually a Promise don't work in Angular, because the native Promise implementation is patched. These additional conditions handle if the object is a ZoneAwarePromise.

I'm not sure if these additional conditions would have any side-effects, as I only tested it with Angular and I'm not very familiar with the detailed workings of the library.

This PR fixes issue #90 