### PR TITLE
Default null to nil when injectObjects is not set

### DIFF
--- a/src/engine.ts
+++ b/src/engine.ts
@@ -31,11 +31,9 @@ export default class LuaEngine {
         // Contains the :await functionality.
         this.global.registerTypeExtension(1, createPromiseType(this.global, injectObjects))
 
-        if (injectObjects) {
-            // Should be higher priority than table since that catches generic objects along
-            // with userdata so it doesn't end up a userdata type.
-            this.global.registerTypeExtension(5, createNullType(this.global))
-        }
+        // Should be higher priority than table since that catches generic objects along
+        // with userdata so it doesn't end up a userdata type.
+        this.global.registerTypeExtension(5, createNullType(this.global, injectObjects))
 
         if (enableProxy) {
             // This extension only really overrides tables and arrays.

--- a/src/type-extensions/default-null.ts
+++ b/src/type-extensions/default-null.ts
@@ -1,0 +1,25 @@
+import Global from '../global'
+import Thread from '../thread'
+import TypeExtension from '../type-extension'
+
+// A default extension that treats js null as lua nil
+class DefaultNullTypeExtension extends TypeExtension<unknown> {
+    constructor(thread: Global) {
+        super(thread, 'js_null')
+    }
+    public getValue(): null {
+        throw new Error('nil values should be converted by pushValue')
+    }
+    public pushValue(thread: Thread, decoration: any): boolean {
+        if (decoration?.target !== null) {
+            return false
+        }
+        thread.lua.lua_pushnil(thread.address)
+        return true
+    }
+    public close(): void {}
+}
+
+export default function createTypeExtension(thread: Global): TypeExtension<null> {
+    return new DefaultNullTypeExtension(thread)
+}

--- a/src/type-extensions/null.ts
+++ b/src/type-extensions/null.ts
@@ -3,6 +3,7 @@ import { LuaReturn, LuaState } from '../types'
 import Global from '../global'
 import Thread from '../thread'
 import TypeExtension from '../type-extension'
+import createDefaultNullType from './default-null'
 
 class NullTypeExtension extends TypeExtension<unknown> {
     private gcPointer: number
@@ -73,6 +74,9 @@ class NullTypeExtension extends TypeExtension<unknown> {
     }
 }
 
-export default function createTypeExtension(thread: Global): TypeExtension<null> {
-    return new NullTypeExtension(thread)
+export default function createTypeExtension(thread: Global, userDataType: boolean): TypeExtension<null> {
+    if (userDataType) {
+        return new NullTypeExtension(thread)
+    }
+    return createDefaultNullType(thread)
 }

--- a/src/type-extensions/promise.ts
+++ b/src/type-extensions/promise.ts
@@ -131,7 +131,7 @@ class PromiseTypeExtension<T = unknown> extends TypeExtension<Promise<T>> {
     }
 
     public pushValue(thread: Thread, decoration: Decoration<Promise<T>>): boolean {
-        if (Promise.resolve(decoration.target) !== decoration.target && typeof decoration.target.then !== 'function') {
+        if (Promise.resolve(decoration.target) !== decoration.target && typeof decoration.target?.then !== 'function') {
             return false
         }
         return super.pushValue(thread, decoration)

--- a/test/engine.test.js
+++ b/test/engine.test.js
@@ -782,6 +782,18 @@ describe('Engine', () => {
         expect(res).to.deep.equal([null, null, 'null'])
     })
 
+    it('null injected as nil', async () => {
+        const engine = await getEngine({ injectObjects: false })
+        engine.global.loadString(`
+        local args = { ... }
+        assert(type(args[1]) == "nil", string.format("expected first argument to be nil, got %s", type(args[1])))
+        return nil, args[1], tostring(nil)
+      `)
+        engine.global.pushValue(null)
+        const res = await engine.global.run(1)
+        expect(res).to.deep.equal([null, null, 'nil'])
+    })
+
     it('Nested callback from JS to Lua', async () => {
         const engine = await getEngine()
         engine.global.set('call', (fn) => fn())


### PR DESCRIPTION
The PR #101 handles null values only when `injectObjects` is set to true. When `injectObjects` is undefined or false, null values are not handled at all, somehow triggering a `TypeError` in `PromiseTypeExtension`.

```js
const { LuaFactory } = require('wasmoon')
const L = await factory.createEngine({ injectObjects: false })
L.global.pushValue(null) // TypeError here
```

```
Uncaught TypeError: Cannot read properties of null (reading 'then')
    at PromiseTypeExtension.pushValue (.../node_modules/.pnpm/wasmoon@1.16.0/node_modules/wasmoon/dist/index.js:916:102)
    at .../node_modules/.pnpm/wasmoon@1.16.0/node_modules/wasmoon/dist/index.js:244:82
    at Array.find (<anonymous>)
    at Global.pushValue (.../node_modules/.pnpm/wasmoon@1.16.0/node_modules/wasmoon/dist/index.js:244:46)
```

This PR adds a simple `DefaultNullTypeExtension` for cases when `injectObjects` is false.