### PR TITLE
Support `:await()` in functions called from Javascript

### DIFF
--- a/test/engine.test.js
+++ b/test/engine.test.js
@@ -717,10 +717,7 @@ describe('Engine', () => {
         expect(res).to.be.equal('1689031554550')
     })
 
-    it('yielding in a JS callback into Lua does not break lua state', async () => {
-        // When yielding within a callback the error 'attempt to yield across a C-call boundary'.
-        // This test just checks that throwing that error still allows the lua global to be
-        // re-used and doesn't cause JS to abort or some nonsense.
+    it('yielding in a JS callback into Lua should succeed', async () => {
         const engine = await getEngine()
         const testEmitter = new EventEmitter()
         engine.global.set('yield', () => new Promise((resolve) => testEmitter.once('resolve', resolve)))
@@ -729,13 +726,11 @@ describe('Engine', () => {
             coroutine.yield()
             return 15
         end)
-        print("res", res:await())
+        return res:await()
       `)
 
         testEmitter.emit('resolve')
-        await expect(resPromise).to.eventually.be.rejectedWith('Error: attempt to yield across a C-call boundary')
-
-        expect(await engine.doString(`return 42`)).to.equal(42)
+        expect(await resPromise).to.equal(15)
     })
 
     it('forced yield within JS callback from Lua doesnt cause vm to crash', async () => {

--- a/test/promises.test.js
+++ b/test/promises.test.js
@@ -1,3 +1,4 @@
+import { EventEmitter } from 'events'
 import { expect } from 'chai'
 import { getEngine, tick } from './utils.js'
 import { mock } from 'node:test'
@@ -144,6 +145,26 @@ describe('Promises', () => {
 
         const asyncFunctionPromise = asyncThread.run()
         expect(await asyncFunctionPromise).to.be.eql([50])
+    })
+
+    it('await in a Lua function called from a JS callback should succeed', async () => {
+        const engine = await getEngine()
+        const testEmitter = new EventEmitter()
+        const promiseEmitter = new EventEmitter()
+        engine.global.set('promise', new Promise((resolve) => promiseEmitter.once('resolve', resolve)))
+        engine.global.set('yield', () => new Promise((resolve) => testEmitter.once('resolve', resolve)))
+        const resPromise = engine.doString(`
+        local res = yield():next(function ()
+            promise:await()
+            return 20
+        end)
+        return res:await()
+      `)
+
+        testEmitter.emit('resolve')
+        setTimeout(() => promiseEmitter.emit('resolve'), 50)
+
+        expect(await resPromise).to.equal(20)
     })
 
     it('run thread with async calls and yields should succeed', async () => {


### PR DESCRIPTION
This PR removes the limitation of awaiting promises in Lua functions that are called from Javascript.

**Effect**
If a Lua function is called from Javascript, it will still return the value returned by the Lua function. However, if the Lua function attempts to yield at any point, a Promise is instead returned to Javascript which either resolves to the return value of the Lua function once it completes or catches if a Lua error occurs.

**Technical Explanation**
The limitation was solved by calling the function thread via `lua_resume()` instead of `lua_pcallk()` and then handing over the thread to `Thread.run()` (which enables the usage of await) in the case that the returned result is `LuaReturn.Yield`.