### PR TITLE
call function with new keyword when calling classes

### DIFF
--- a/src/type-extensions/function.ts
+++ b/src/type-extensions/function.ts
@@ -103,9 +103,12 @@ class FunctionTypeExtension extends TypeExtension<FunctionType, FunctionDecorati
             }
 
             try {
-                let result;
-                if (target.prototype) result = new (target as any)(...args);
-                else result = target.apply(options?.self, args);
+                let result
+                if (target.prototype) {
+                    result = new (target as any)(...args)
+                } else {
+                    result = target.apply(options?.self, args)
+                }
 
                 if (result === undefined) {
                     return 0

--- a/src/type-extensions/function.ts
+++ b/src/type-extensions/function.ts
@@ -103,7 +103,9 @@ class FunctionTypeExtension extends TypeExtension<FunctionType, FunctionDecorati
             }
 
             try {
-                const result = target.apply(options?.self, args)
+                let result;
+                if (target.prototype) result = new (target as any)(...args);
+                else result = target.apply(options?.self, args);
 
                 if (result === undefined) {
                     return 0

--- a/test/engine.test.js
+++ b/test/engine.test.js
@@ -806,13 +806,13 @@ describe('Engine', () => {
 
     it('lots of doString calls should succeed', async () => {
         const engine = await getEngine()
-        const length = 10000;
+        const length = 10000
 
         for (let i = 0; i < length; i++) {
-            const a = Math.floor(Math.random() * 100);
-            const b = Math.floor(Math.random() * 100);
-            const result = await engine.doString(`return ${a} + ${b};`);
-            expect(result).to.equal(a + b);
+            const a = Math.floor(Math.random() * 100)
+            const b = Math.floor(Math.random() * 100)
+            const result = await engine.doString(`return ${a} + ${b};`)
+            expect(result).to.equal(a + b)
         }
     })
 })


### PR DESCRIPTION
This PR adds support for calling constructors!

It triggers when calling a javascript class from lua. Classes are distinguished from generic functions by the `.constructor`-field.

**Syntax:**

```lua
local ws = window.WebSocket("https://example.org")

-- ws is a new instance of WebSocket
ws.send 'hello example.org!'
```